### PR TITLE
Fix crash and httpBody not being set

### DIFF
--- a/Sources/PostgREST/PostgrestBuilder.swift
+++ b/Sources/PostgREST/PostgrestBuilder.swift
@@ -138,6 +138,9 @@ public class PostgrestBuilder {
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.allHTTPHeaderFields = headers
+        if let body = body {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+        }
         return request
     }
 

--- a/Sources/PostgREST/PostgrestError.swift
+++ b/Sources/PostgREST/PostgrestError.swift
@@ -7,16 +7,13 @@ public struct PostgrestError: Error {
     public var message: String
 
     init?(from dictionary: [String: Any]) {
-        guard let details = dictionary["details"] as? String,
-              let hint = dictionary["hint"] as? String,
-              let code = dictionary["code"] as? String,
-              let message = dictionary["message"] as? String
-        else {
+        guard let message = dictionary["message"] as? String else {
             return nil
         }
-        self.details = details
-        self.hint = hint
-        self.code = code
+
+        self.details = dictionary["details"] as? String
+        self.hint = dictionary["hint"] as? String
+        self.code = dictionary["code"] as? String
         self.message = message
     }
 

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -22,6 +22,11 @@ final class BuildURLRequestTests: XCTestCase {
                     .select()
                     .like(column: "email", value: "%@supabase.co")
                     .buildURLRequest(head: false, count: nil)
+            },
+            TestCase(name: "insert new user") { client in
+                try client.form("users")
+                    .insert(values: ["email": "johndoe@supabase.io"])
+                    .buildURLRequest(head: false, count: nil)
             }
         ]
 

--- a/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildURLRequest.insert-new-user.txt
+++ b/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildURLRequest.insert-new-user.txt
@@ -1,0 +1,5 @@
+curl \
+	--request POST \
+	--header "Prefer: return=representation" \
+	--data "{\"email\":\"johndoe@supabase.io\"}" \
+	"https://example.supabase.co/users"


### PR DESCRIPTION
## Changes

* This PR chages the `unowned self` to a `weak self` inside the `execute` method as isn't guaranteed that the `PostgresBuilder` class will still be alive when the response returns.
* The `httpBody` wasn't being set when building the request.