### PR TITLE
Refactor and improves `PostgrestResponse` type

### DIFF
--- a/Sources/PostgREST/PostgrestError.swift
+++ b/Sources/PostgREST/PostgrestError.swift
@@ -1,23 +1,15 @@
 import Foundation
 
-public struct PostgrestError: Error {
-    public var details: String?
-    public var hint: String?
-    public var code: String?
-    public var message: String
-
-    init?(from dictionary: [String: Any]) {
-        guard let message = dictionary["message"] as? String else {
-            return nil
-        }
-
-        details = dictionary["details"] as? String
-        hint = dictionary["hint"] as? String
-        code = dictionary["code"] as? String
-        self.message = message
-    }
-
-    init(message: String) {
+public struct PostgrestError: Error, Codable {
+    public let details: String?
+    public let hint: String?
+    public let code: String?
+    public let message: String
+    
+    public init(details: String? = nil, hint: String? = nil, code: String? = nil, message: String) {
+        self.hint = hint
+        self.details = details
+        self.code = code
         self.message = message
     }
 }

--- a/Sources/PostgREST/PostgrestResponse.swift
+++ b/Sources/PostgREST/PostgrestResponse.swift
@@ -11,3 +11,18 @@ public struct PostgrestResponse: Hashable {
         self.count = count
     }
 }
+
+extension PostgrestResponse {
+
+    public func json() throws -> Any {
+        try JSONSerialization.jsonObject(with: data, options: [.allowFragments])
+    }
+
+    public func decoded<T: Decodable>(to type: T.Type = T.self, using decoder: JSONDecoder = JSONDecoder()) throws -> T {
+        try decoder.decode(type, from: data)
+    }
+
+    public func string(encoding: String.Encoding = .utf8) -> String? {
+        String(data: data, encoding: encoding)
+    }
+}

--- a/Sources/PostgREST/PostgrestResponse.swift
+++ b/Sources/PostgREST/PostgrestResponse.swift
@@ -1,29 +1,13 @@
-public class PostgrestResponse {
-    public var body: Any
-    public var status: Int?
-    public var count: Int?
-    public var error: PostgrestError?
+import Foundation
 
-    init(body: Any) {
-        self.body = body
-    }
+public struct PostgrestResponse: Hashable {
+    public let data: Data
+    public let status: Int
+    public let count: Int?
 
-    init?(from dictionary: [String: Any]) {
-        guard let body = dictionary["body"] else {
-            return nil
-        }
-        self.body = body
-
-        if let status: Int = dictionary["status"] as? Int {
-            self.status = status
-        }
-
-        if let count: Int = dictionary["count"] as? Int {
-            self.count = count
-        }
-
-        if let error: [String: Any] = dictionary["error"] as? [String: Any] {
-            self.error = PostgrestError(from: error)
-        }
+    public init(data: Data, status: Int, count: Int?) {
+        self.data = data
+        self.status = status
+        self.count = count
     }
 }

--- a/Sources/example/main.swift
+++ b/Sources/example/main.swift
@@ -17,9 +17,8 @@ struct Todo: Codable {
 database.from("todo").select().execute { result in
     switch result {
     case let .success(response):
-        let data = response.data
         do {
-            let todos = try JSONDecoder().decode([Todo].self, from: data)
+            let todos = try response.decoded(to: [Todo].self)
             print(todos)
         } catch {
             print(error.localizedDescription)
@@ -36,9 +35,8 @@ do {
     database.from("todo").insert(values: jsonData).execute { result in
         switch result {
         case let .success(response):
-            let data = response.data
             do {
-                let todos = try JSONDecoder().decode([Todo].self, from: data)
+                let todos = try response.decoded(to: [Todo].self)
                 print(todos)
             } catch {
                 print(error.localizedDescription)

--- a/Sources/example/main.swift
+++ b/Sources/example/main.swift
@@ -17,9 +17,7 @@ struct Todo: Codable {
 database.from("todo").select().execute { result in
     switch result {
     case let .success(response):
-        guard let data = response.body as? Data else {
-            return
-        }
+        let data = response.data
         do {
             let todos = try JSONDecoder().decode([Todo].self, from: data)
             print(todos)
@@ -38,9 +36,7 @@ do {
     database.from("todo").insert(values: jsonData).execute { result in
         switch result {
         case let .success(response):
-            guard let data = response.body as? Data else {
-                return
-            }
+            let data = response.data
             do {
                 let todos = try JSONDecoder().decode([Todo].self, from: data)
                 print(todos)


### PR DESCRIPTION
## Changes

* Change `PostgrestResponse` body type from `Any` to `Data`
* Add helper methods for deserializing `PostgrestResponse` into `json`, `string` and `Decodable`.
* Add Codable support for`PostgrestError` type and remove raw dictionary initializer.
