### PR TITLE
Add public config

### DIFF
--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -24,6 +24,12 @@ public class PostgrestClient {
                                             headers: headers,
                                             schema: schema)
     }
+    
+    /// Initializes the `PostgrestClient` with a config object
+    /// - Parameter config: A `PostgrestClientConfig` struct with the correct parameters
+    public init(config: PostgrestClientConfig) {
+        self.config = config
+    }
 
     /// Select a table to query from
     /// - Parameter table: The ID of the table to query

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -4,9 +4,15 @@
  This is the main class in this package. Use it to execute queries on a PostgREST instance on Supabase.
  */
 public class PostgrestClient {
-    var url: String
-    var headers: [String: String]
-    var schema: String?
+    /// Configuration for the client
+    public var config: PostgrestClientConfig
+    
+    /// Struct for PostgrestClient config options
+    public struct PostgrestClientConfig {
+        public var url: String
+        public var headers: [String: String]
+        public var schema: String?
+    }
 
     /// Initializes the `PostgrestClient` with the correct parameters.
     /// - Parameters:
@@ -14,16 +20,16 @@ public class PostgrestClient {
     ///   - headers: Headers to include when querying the database. Eg, an authentication header
     ///   - schema: Schema ID to use
     public init(url: String, headers: [String: String] = [:], schema: String?) {
-        self.url = url
-        self.headers = headers
-        self.schema = schema
+        self.config = PostgrestClientConfig(url: url,
+                                            headers: headers,
+                                            schema: schema)
     }
 
     /// Select a table to query from
     /// - Parameter table: The ID of the table to query
     /// - Returns: `PostgrestQueryBuilder`
     public func from(_ table: String) -> PostgrestQueryBuilder {
-        return PostgrestQueryBuilder(url: "\(url)/\(table)", queryParams: [], headers: headers, schema: schema, method: nil, body: nil)
+        return PostgrestQueryBuilder(url: "\(config.url)/\(table)", queryParams: [], headers: config.headers, schema: config.schema, method: nil, body: nil)
     }
 
     /// Call a stored procedure, aka a "Remote Procedure Call"
@@ -32,6 +38,6 @@ public class PostgrestClient {
     ///   - parameters: Parameters to pass to the procedure.
     /// - Returns: `PostgrestTransformBuilder`
     public func rpc(fn: String, parameters: [String: Any]?) -> PostgrestTransformBuilder {
-        return PostgrestRpcBuilder(url: "\(url)/rpc/\(fn)", queryParams: [], headers: headers, schema: schema, method: nil, body: nil).rpc(parameters: parameters)
+        return PostgrestRpcBuilder(url: "\(config.url)/rpc/\(fn)", queryParams: [], headers: config.headers, schema: config.schema, method: nil, body: nil).rpc(parameters: parameters)
     }
 }

--- a/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildURLRequest.call-rpc.txt
+++ b/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildURLRequest.call-rpc.txt
@@ -1,4 +1,5 @@
 curl \
 	--request POST \
+	--header "Content-Type: application/json" \
 	--data "{\"KEY\":\"VALUE\"}" \
 	"https://example.supabase.co/rpc/test_fcn"

--- a/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildURLRequest.insert-new-user.txt
+++ b/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildURLRequest.insert-new-user.txt
@@ -1,5 +1,6 @@
 curl \
 	--request POST \
+	--header "Content-Type: application/json" \
 	--header "Prefer: return=representation" \
 	--data "{\"email\":\"johndoe@supabase.io\"}" \
 	"https://example.supabase.co/users"


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Makes `PostgrestClient` config options public, and puts them in a separate struct for a simpler API.
- Adds an init method to the `PostgrestClient` for initalizing with a config object.
- Fixes test cases (add Content-Type header to all requests)

This change is mostly to make the `headers`, `url` and `schema` public variables, but I've moved them into their own struct to make the public client API less confusing with lots of public variables.

## What is the current behavior?

Right now PostgrestClient's config variables are private from outside the module, this becomes an issue when dealing with Auth, as the headers aren't mutable. This PR changes that by making the config variables mutable and public.

- _test cases were broken after the last PR that added the ContentType application/json header to all requests_

## What is the new behavior?

```swift
// Config object
let config = PostgrestClientConfig(url: "abc.supabase.io",
                                            headers: ["apikey": "1234"],
                                            schema: nil)

// New initalizer
let client = PostgrestClient(config)

// Modify the auth header
client.config.headers["Authorization"] = "Bearer: 12345" // now using bearer token auth for requests

// Modify the url
client.config.url = "123.supabse.io"
```

