### PR TITLE
Add async/await support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "PostgREST",
+    platforms: [.iOS(.v11), .macOS(.v10_10)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/PostgREST/Concurrency.swift
+++ b/Sources/PostgREST/Concurrency.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+#if compiler(>=5.5)
 @available(iOS 15.0.0, macOS 12.0.0, *)
 extension PostgrestBuilder {
   public func execute(head: Bool = false, count: CountOption? = nil) async throws -> PostgrestResponse {
@@ -10,3 +11,4 @@ extension PostgrestBuilder {
     }
   }
 }
+#endif

--- a/Sources/PostgREST/Concurrency.swift
+++ b/Sources/PostgREST/Concurrency.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+@available(iOS 15.0.0, macOS 12.0.0, *)
+extension PostgrestBuilder {
+  public func execute(head: Bool = false, count: CountOption? = nil) async throws -> PostgrestResponse {
+    try await withCheckedThrowingContinuation { continuation in
+      self.execute(head: head, count: count) { result in
+        continuation.resume(with: result)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Changes

Adds an `async/await` version of the `execute` method constrained to `iOS 15` and `macOS 12`.

```swift
func execute(head: Bool = false, count: CountOption? = nil) async throws -> PostgrestResponse
```