### PR TITLE
Add Linux compatibility.

### DIFF
--- a/Sources/PostgREST/PostgrestBuilder.swift
+++ b/Sources/PostgREST/PostgrestBuilder.swift
@@ -1,5 +1,9 @@
 import AnyCodable
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 
 public class PostgrestBuilder {
   var url: String

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import SnapshotTesting
 import XCTest
 


### PR DESCRIPTION
Add `FoundationNetworking` if available.
This is allowing Linux platforms to compile the framework, since the migration of URL-related function to the `FoundationNetworking` framework.