### PR TITLE
correcting these parameters to be arrays

### DIFF
--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -73,8 +73,8 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder {
     return self
   }
 
-  public func contains(column: String, value: [URLQueryRepresentable]) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "cs.(\(value.map(\.queryValue).joined(separator: ",")))")
+  public func contains(column: String, value: URLQueryRepresentable) -> PostgrestFilterBuilder {
+    appendSearchParams(name: column, value: "cs.\(value.queryValue)")
     return self
   }
 
@@ -104,8 +104,8 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder {
     return self
   }
 
-  public func overlaps(column: String, value: [URLQueryRepresentable]) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "ov.(\(value.map(\.queryValue).joined(separator: ",")))")
+  public func overlaps(column: String, value: URLQueryRepresentable) -> PostgrestFilterBuilder {
+    appendSearchParams(name: column, value: "ov.\(value.queryValue)")
     return self
   }
 

--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -73,8 +73,8 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder {
     return self
   }
 
-  public func contains(column: String, value: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "cs.\(value.queryValue)")
+  public func contains(column: String, value: [URLQueryRepresentable]) -> PostgrestFilterBuilder {
+    appendSearchParams(name: column, value: "cs.(\(value.map(\.queryValue).joined(separator: ",")))")
     return self
   }
 
@@ -104,8 +104,8 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder {
     return self
   }
 
-  public func overlaps(column: String, value: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "ov.\(value.queryValue)")
+  public func overlaps(column: String, value: [URLQueryRepresentable]) -> PostgrestFilterBuilder {
+    appendSearchParams(name: column, value: "ov.(\(value.map(\.queryValue).joined(separator: ",")))")
     return self
   }
 

--- a/Sources/PostgREST/URLQueryRepresentable.swift
+++ b/Sources/PostgREST/URLQueryRepresentable.swift
@@ -25,3 +25,15 @@ extension Bool: URLQueryRepresentable {
 extension UUID: URLQueryRepresentable {
   public var queryValue: String { uuidString }
 }
+
+extension Array: URLQueryRepresentable where Element: URLQueryRepresentable {
+  public var queryValue: String {
+      self.map(\.queryValue).joined(separator: ",")
+  }
+}
+
+extension Dictionary: URLQueryRepresentable where Element: URLQueryRepresentable {
+  public var queryValue: String {
+      self.map { "\($0.key)=\($0.value)" }.joined(separator: ",")
+  }
+}

--- a/Sources/PostgREST/URLQueryRepresentable.swift
+++ b/Sources/PostgREST/URLQueryRepresentable.swift
@@ -28,12 +28,26 @@ extension UUID: URLQueryRepresentable {
 
 extension Array: URLQueryRepresentable where Element: URLQueryRepresentable {
   public var queryValue: String {
-      self.map(\.queryValue).joined(separator: ",")
+    "{\(map(\.queryValue).joined(separator: ","))}"
   }
 }
 
-extension Dictionary: URLQueryRepresentable where Element: URLQueryRepresentable {
+extension Dictionary: URLQueryRepresentable where Key: URLQueryRepresentable,
+  Value: URLQueryRepresentable
+{
   public var queryValue: String {
-      self.map { "\($0.key)=\($0.value)" }.joined(separator: ",")
+    JSONSerialization.stringfy(self)
+  }
+}
+
+extension JSONSerialization {
+  static func stringfy(_ object: Any) -> String {
+    guard
+      let data = try? data(withJSONObject: object, options: [.withoutEscapingSlashes, .sortedKeys]),
+      let string = String(data: data, encoding: .utf8)
+    else {
+      return "{}"
+    }
+    return string
   }
 }

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -69,6 +69,15 @@
         TestCase(name: "test in filter") { client in
           client.from("todos").select().in(column: "id", value: [1, 2, 3])
         },
+        TestCase(name: "test contains filter with dictionary") { client in
+          client.from("users").select(columns: "name")
+            .contains(column: "address", value: ["postcode": 90210])
+        },
+        TestCase(name: "test contains filter with array") { client in
+          client.from("users")
+            .select()
+            .contains(column: "name", value: ["is:online", "faction:red"])
+        },
       ]
 
       for testCase in testCases {

--- a/Tests/PostgRESTTests/URLQueryRepresentableTests.swift
+++ b/Tests/PostgRESTTests/URLQueryRepresentableTests.swift
@@ -2,7 +2,11 @@ import PostgREST
 import XCTest
 
 final class URLQueryRepresentableTests: XCTestCase {
-  func testArray() {}
+  func testArray() {
+    let array = ["is:online", "faction:red"]
+    let queryValue = array.queryValue
+    XCTAssertEqual(queryValue, "{is:online,faction:red}")
+  }
 
   func testDictionary() {
     let dictionary = ["postalcode": 90210]

--- a/Tests/PostgRESTTests/URLQueryRepresentableTests.swift
+++ b/Tests/PostgRESTTests/URLQueryRepresentableTests.swift
@@ -1,0 +1,12 @@
+import PostgREST
+import XCTest
+
+final class URLQueryRepresentableTests: XCTestCase {
+  func testArray() {}
+
+  func testDictionary() {
+    let dictionary = ["postalcode": 90210]
+    let queryValue = dictionary.queryValue
+    XCTAssertEqual(queryValue, "{\"postalcode\":90210}")
+  }
+}

--- a/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.test-contains-filter-with-array.txt
+++ b/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.test-contains-filter-with-array.txt
@@ -1,0 +1,4 @@
+curl \
+	--header "Accept: application/json" \
+	--header "Content-Type: application/json" \
+	"https://example.supabase.co/users?name=cs.%7Bis:online,faction:red%7D&select=*"

--- a/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.test-contains-filter-with-dictionary.txt
+++ b/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.test-contains-filter-with-dictionary.txt
@@ -1,0 +1,4 @@
+curl \
+	--header "Accept: application/json" \
+	--header "Content-Type: application/json" \
+	"https://example.supabase.co/users?address=cs.%7B%22postcode%22:90210%7D&select=name"


### PR DESCRIPTION
## What kind of change does this PR introduce?

When using the `.contains` function, I noticed I was unable to pass an array object. As noted in the documentation [here](https://supabase.com/docs/reference/javascript/contains), the expected parameter for `value` should be an array, but like when passing a value to the `.in` function.

## What is the current behavior?

The current incorrectly accepts a singular value for the `.contains` function. When making a call, an error will occur, suggesting that an array needs to be passed.

## What is the new behavior?

The new behavior allows for an array to be passed. The array is processed as any other list is when passed (much like the `.in` functionality)