### PR TITLE
Added select with foreign table

### DIFF
--- a/Sources/PostgREST/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/PostgrestQueryBuilder.swift
@@ -50,7 +50,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
         return String(char)
       }
         .joined(separator: "")
-      selectQueryValue = "\(cleanedForeignTable)(\(cleanedForeignTableColum))"
+      selectQueryValue += "\(cleanedForeignTable)(\(cleanedForeignTableColum))"
     }
     appendSearchParams(name: "select", value: selectQueryValue)
     if let count = count {

--- a/Sources/PostgREST/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/PostgrestQueryBuilder.swift
@@ -50,7 +50,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
         return String(char)
       }
         .joined(separator: "")
-      selectQueryValue += "\(cleanedForeignTable)(\(cleanedForeignTableColum))"
+      selectQueryValue += ",\(cleanedForeignTable)(\(cleanedForeignTableColum))"
     }
     appendSearchParams(name: "select", value: selectQueryValue)
     if let count = count {

--- a/Sources/PostgREST/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/PostgrestQueryBuilder.swift
@@ -50,7 +50,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
         return String(char)
       }
         .joined(separator: "")
-      selectQueryValue = "\(cleanedForeignTable)\\(\(cleanedForeignTableColum)\\)"
+      selectQueryValue = "\(cleanedForeignTable)(\(cleanedForeignTableColum))"
     }
     appendSearchParams(name: "select", value: selectQueryValue)
     if let count = count {

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -96,6 +96,11 @@
             .select()
             .gt(column: "received_at", value: "2023-03-23T15:50:30.511743+00:00")
             .order(column: "received_at")
+        },
+        TestCase(name: "query with foreign table") { client in
+          client.from("user")
+            .select(foreignTable: "tasks")
+            .eq(column: "id", value: "Cigányka-ér (0+400 cskm) vízrajzi állomás")
         }
       ]
 

--- a/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.query-with-foreign-table.txt
+++ b/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.query-with-foreign-table.txt
@@ -1,0 +1,4 @@
+curl \
+	--header "Accept: application/json" \
+	--header "Content-Type: application/json" \
+	"https://example.supabase.co/user?id=eq.Cig%C3%A1nyka-%C3%A9r%20(0+400%20cskm)%20v%C3%ADzrajzi%20%C3%A1llom%C3%A1s&select=tasks%5C(*%5C)"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR introduce capability to query foreign tables using select

## What is the current behavior?

Current api does not support querying  foreign table like JS version https://supabase.com/docs/reference/javascript/select?example=query-foreign-tables

## What is the new behavior?

New API would enable configuring the query to fetch foreign tables similar to JS SDK

## Additional context

NA