### PR TITLE
fix: rpc call returns PostgrestFilterBuilder

### DIFF
--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -56,7 +56,7 @@ public class PostgrestClient {
     fn: String,
     params: U,
     count: CountOption? = nil
-  ) -> PostgrestTransformBuilder {
+  ) -> PostgrestFilterBuilder {
     PostgrestRpcBuilder(
       client: self,
       request: Request(
@@ -76,7 +76,7 @@ public class PostgrestClient {
   public func rpc(
     fn: String,
     count: CountOption? = nil
-  ) -> PostgrestTransformBuilder {
+  ) -> PostgrestFilterBuilder {
     rpc(fn: fn, params: NoParams(), count: count)
   }
 }

--- a/Sources/PostgREST/PostgrestRpcBuilder.swift
+++ b/Sources/PostgREST/PostgrestRpcBuilder.swift
@@ -7,7 +7,7 @@ public final class PostgrestRpcBuilder: PostgrestBuilder {
     params: U,
     head: Bool = false,
     count: CountOption? = nil
-  ) -> PostgrestTransformBuilder {
+  ) -> PostgrestFilterBuilder {
     // TODO: Support `HEAD` method
     // https://github.com/supabase/postgrest-js/blob/master/src/lib/PostgrestRpcBuilder.ts#L38
     assert(head == false, "HEAD is not currently supported yet.")
@@ -27,6 +27,6 @@ public final class PostgrestRpcBuilder: PostgrestBuilder {
       }
     }
 
-    return PostgrestTransformBuilder(self)
+    return PostgrestFilterBuilder(self)
   }
 }


### PR DESCRIPTION
fixes supabase-community/supabase-swift#110

## What kind of change does this PR introduce?

Changes the return value of the `rpc` call to return `PostgrestFilterBuilder` instead of `PostgrestTransformBuilder`, which allows for use of the filter functions like `.neq`, `.eq`, etc. 
This appropriately changes the return value to be the same as in [postgrest-js](https://github.com/supabase/postgrest-js/blob/7b0a69660e20ac11d7c3720604e338adb2e33d0a/src/PostgrestClient.ts#L140)

## What is the current behavior?
At the moment, an `.rpc` call would return `PostgrestTransformBuilder` which only has the available methods `select`, `order`, `limit`, `range`. 

Please link any relevant issues here.
https://github.com/supabase-community/supabase-swift/issues/110

## What is the new behavior?
The `.rpc` call returns a `PostgrestFilterBuilder` object.


## Additional context
New filter options compared to the other screenshot in the linked issue.

<img width="895" alt="image" src="https://github.com/supabase-community/postgrest-swift/assets/15935660/f0b8fd05-6fdf-4c91-a342-351b9f76e07f">

Tested a couple of filters and seems to work fine returning the expected data.