### PR TITLE
chore: fix build by defining closure return type

### DIFF
--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -127,13 +127,13 @@ struct PostgrestAPIClientDelegate: APIClientDelegate {
   }
 
   private func query(_ parameters: [(String, String?)]) -> String {
-    parameters.compactMap { key, value in
+    parameters.compactMap { key, value -> (String, String)? in
       if let value {
         return (key, value)
       }
       return nil
     }
-    .map { key, value in
+    .map { key, value -> String in
       let escapedKey = escape(key)
       let escapedValue = escape(value)
       return "\(escapedKey)=\(escapedValue)"

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -96,7 +96,7 @@
             .select()
             .gt(column: "received_at", value: "2023-03-23T15:50:30.511743+00:00")
             .order(column: "received_at")
-        }
+        },
       ]
 
       for testCase in testCases {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix #51

## What is the current behavior?

The code doesn't build on the old Swift version.

## What is the new behavior?

Add return type to closure to help the compiler disambiguate code.